### PR TITLE
#1 Use Replace instead of ToCharArray on auth

### DIFF
--- a/src/Vendr.Contrib.PaymentProviders.Nets/Easy/NetsEasyOneTimePaymentProvider.cs
+++ b/src/Vendr.Contrib.PaymentProviders.Nets/Easy/NetsEasyOneTimePaymentProvider.cs
@@ -702,7 +702,7 @@ namespace Vendr.Contrib.PaymentProviders
         {
             var prefix = settings.TestMode ? "test-secret-key-" : "live-secret-key-";
             var secretKey = settings.TestMode ? settings.TestSecretKey : settings.LiveSecretKey;
-            var auth = secretKey?.Trim().TrimStart(prefix.ToCharArray());
+            var auth = secretKey?.Trim().Replace(prefix, string.Empty);
 
             return new NetsEasyClientConfig
             {


### PR DESCRIPTION
Replace instead of ToCharArray in order not to cut any unnecessary letters from the secret key.

Reference https://github.com/vendrcontrib/vendr-payment-provider-nets/issues/1